### PR TITLE
Fix `Log` to print directly

### DIFF
--- a/lib/gum/command.rb
+++ b/lib/gum/command.rb
@@ -7,9 +7,9 @@ require "open3"
 
 module Gum
   module Command
-    def self.run(*, input: nil, interactive: true)
+    def self.run(*, input: nil, interactive: true, output: :stdout)
       if !interactive
-        run_non_interactive(*, input: input)
+        run_non_interactive(*, input: input, output: output)
       elsif input
         run_interactive_with_input(*, input: input)
       else
@@ -17,7 +17,7 @@ module Gum
       end
     end
 
-    def self.run_non_interactive(*args, input:)
+    def self.run_non_interactive(*args, input:, output: :stdout)
       stdout, stderr, status = Open3.capture3(color_env, Gum.executable, *args.map(&:to_s), stdin_data: input)
 
       unless status.success?
@@ -26,7 +26,7 @@ module Gum
         raise Error, "gum #{args.first} failed: #{stderr}" unless stderr.empty?
       end
 
-      stdout.chomp
+      (output == :stderr ? stderr : stdout).chomp
     end
 
     def self.run_interactive(*args)
@@ -106,7 +106,7 @@ module Gum
         _stdout, _stderr, status = Open3.capture3(color_env, Gum.executable, *args.map(&:to_s), stdin_data: input)
         status.success?
       else
-        system(COLOR_ENV, Gum.executable, *args.map(&:to_s))
+        system(color_env, Gum.executable, *args.map(&:to_s))
       end
     end
 

--- a/lib/gum/commands/log.rb
+++ b/lib/gum/commands/log.rb
@@ -30,7 +30,7 @@ module Gum
     # @rbs formatter: Symbol | String | nil -- log formatter (:text, :json, :logfmt)
     # @rbs prefix: String? -- log message prefix
     # @rbs **fields: untyped -- additional key-value fields for structured logging
-    # @rbs return: String? -- formatted log output
+    # @rbs return: bool -- true if logging succeeded
     def self.call(
       message,
       level: nil,
@@ -57,40 +57,40 @@ module Gum
         args << value.to_s
       end
 
-      Command.run(*args, interactive: false)
+      Command.run_with_status(*args)
     end
 
     # @rbs message: String -- log message text
     # @rbs **fields: untyped -- additional key-value fields
-    # @rbs return: String? -- formatted debug log output
+    # @rbs return: bool -- true if logging succeeded
     def self.debug(message, **fields)
       call(message, level: :debug, **fields)
     end
 
     # @rbs message: String -- log message text
     # @rbs **fields: untyped -- additional key-value fields
-    # @rbs return: String? -- formatted info log output
+    # @rbs return: bool -- true if logging succeeded
     def self.info(message, **fields)
       call(message, level: :info, **fields)
     end
 
     # @rbs message: String -- log message text
     # @rbs **fields: untyped -- additional key-value fields
-    # @rbs return: String? -- formatted warn log output
+    # @rbs return: bool -- true if logging succeeded
     def self.warn(message, **fields)
       call(message, level: :warn, **fields)
     end
 
     # @rbs message: String -- log message text
     # @rbs **fields: untyped -- additional key-value fields
-    # @rbs return: String? -- formatted error log output
+    # @rbs return: bool -- true if logging succeeded
     def self.error(message, **fields)
       call(message, level: :error, **fields)
     end
 
     # @rbs message: String -- log message text
     # @rbs **fields: untyped -- additional key-value fields
-    # @rbs return: String? -- formatted fatal log output
+    # @rbs return: bool -- true if logging succeeded
     def self.fatal(message, **fields)
       call(message, level: :fatal, **fields)
     end

--- a/sig/gum.rbs
+++ b/sig/gum.rbs
@@ -35,11 +35,11 @@ module Gum
 
   # Choose from a list of options
   # @see Gum::Choose#call
-  def self.choose: (untyped items, **untyped) -> untyped
+  def self.choose: () -> untyped
 
   # Filter items with fuzzy matching
   # @see Gum::Filter#call
-  def self.filter: (untyped items, **untyped) -> untyped
+  def self.filter: () -> untyped
 
   # Prompt for confirmation
   # @see Gum::Confirm#call

--- a/sig/gum/command.rbs
+++ b/sig/gum/command.rbs
@@ -2,9 +2,9 @@
 
 module Gum
   module Command
-    def self.run: (*untyped, ?input: untyped, ?interactive: untyped) -> untyped
+    def self.run: (*untyped, ?input: untyped, ?interactive: untyped, ?output: untyped) -> untyped
 
-    def self.run_non_interactive: (*untyped args, input: untyped) -> untyped
+    def self.run_non_interactive: (*untyped args, input: untyped, ?output: untyped) -> untyped
 
     def self.run_interactive: (*untyped args) -> untyped
 

--- a/sig/gum/commands/log.rbs
+++ b/sig/gum/commands/log.rbs
@@ -25,32 +25,32 @@ module Gum
     # @rbs formatter: Symbol | String | nil -- log formatter (:text, :json, :logfmt)
     # @rbs prefix: String? -- log message prefix
     # @rbs **fields: untyped -- additional key-value fields for structured logging
-    # @rbs return: String? -- formatted log output
-    def self.call: (String message, ?level: Symbol | String | nil, ?time: Symbol | String | nil, ?structured: bool?, ?formatter: Symbol | String | nil, ?prefix: String?, **untyped fields) -> String?
+    # @rbs return: bool -- true if logging succeeded
+    def self.call: (String message, ?level: Symbol | String | nil, ?time: Symbol | String | nil, ?structured: bool?, ?formatter: Symbol | String | nil, ?prefix: String?, **untyped fields) -> bool
 
     # @rbs message: String -- log message text
     # @rbs **fields: untyped -- additional key-value fields
-    # @rbs return: String? -- formatted debug log output
-    def self.debug: (String message, **untyped fields) -> String?
+    # @rbs return: bool -- true if logging succeeded
+    def self.debug: (String message, **untyped fields) -> bool
 
     # @rbs message: String -- log message text
     # @rbs **fields: untyped -- additional key-value fields
-    # @rbs return: String? -- formatted info log output
-    def self.info: (String message, **untyped fields) -> String?
+    # @rbs return: bool -- true if logging succeeded
+    def self.info: (String message, **untyped fields) -> bool
 
     # @rbs message: String -- log message text
     # @rbs **fields: untyped -- additional key-value fields
-    # @rbs return: String? -- formatted warn log output
-    def self.warn: (String message, **untyped fields) -> String?
+    # @rbs return: bool -- true if logging succeeded
+    def self.warn: (String message, **untyped fields) -> bool
 
     # @rbs message: String -- log message text
     # @rbs **fields: untyped -- additional key-value fields
-    # @rbs return: String? -- formatted error log output
-    def self.error: (String message, **untyped fields) -> String?
+    # @rbs return: bool -- true if logging succeeded
+    def self.error: (String message, **untyped fields) -> bool
 
     # @rbs message: String -- log message text
     # @rbs **fields: untyped -- additional key-value fields
-    # @rbs return: String? -- formatted fatal log output
-    def self.fatal: (String message, **untyped fields) -> String?
+    # @rbs return: bool -- true if logging succeeded
+    def self.fatal: (String message, **untyped fields) -> bool
   end
 end


### PR DESCRIPTION
`gum log` outputs to `stderr`, not `stdout`. Previously, `Log.call` captured `stdout` (which was empty) and returned it. Now `log` prints directly to `stderr` and returns a boolean indicating success, matching how logging typically works:

```ruby
Gum.log("Hello")
```

Resolves #2 